### PR TITLE
gv-MACOSFIX1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ all:
 	@echo RUN \'make install\' to install dds
 
 install:
-	@install -Dm755 $(BIN) $(DESTDIR)$(PREFIX)/bin/$(BIN)
-	@install -Dm755 $(BIN).1 $(DESTDIR)$(MANPREFIX)/man1
+	@install -m755 $(BIN) $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	@install -m755 $(BIN).1 $(DESTDIR)$(MANPREFIX)/man1
 
 uninstall:
 	@rm -f $(DESTDIR)$(PREFIX)/bin/$(BIN)


### PR DESCRIPTION
Tested dd-safe and fixed error with -D flag in Makefile, on macOS Catalina, with David's direction.